### PR TITLE
[리팩토링] 테스트코드 리팩토링

### DIFF
--- a/src/test/java/com/fastcampus/projectboardstart/service/ArticleServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboardstart/service/ArticleServiceTest.java
@@ -343,7 +343,7 @@ class ArticleServiceTest {
         then(hashtagService).should(times(2)).deleteHashtagWithoutArticles(any());
     }
 
-    @DisplayName("게시글 수를 조회하면, 게시글 수를 반환한다")
+    @DisplayName("게시글 수를 조회하면, 게시글 수를 반환한다.")
     @Test
     void givenNothing_whenCountingArticles_thenReturnsArticleCount() {
         // Given


### PR DESCRIPTION
이 pr은 테스트코드의 품질을 관리하기 위해 일부 테스트 제목을 다른 테스트 제목과 일관된 형태로 수정한다.

This closes #81 