### PR TITLE
#92 - 메인 스프링 부트 테스트에서 발생하는 에러 해결

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -51,3 +51,8 @@ spring:
     url: ${JAWSDB_URL}
   jpa.hibernate.ddl-auto: create
   sql.init.mode: always
+
+---
+spring:
+  config.activate.on-profile: test
+  datasource.url: jdbc:h2:mem:testdb

--- a/src/test/java/com/fastcampus/projectboardstart/ProjectBoardApplicationTests.java
+++ b/src/test/java/com/fastcampus/projectboardstart/ProjectBoardApplicationTests.java
@@ -2,7 +2,9 @@ package com.fastcampus.projectboardstart;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class ProjectBoardApplicationTests {
 


### PR DESCRIPTION
DB 접근 정보가 환경변수 문법으로 치환되었는데
`@SpringBootTest`가 이를 그대로 읽으면서
올바른 jdbc url 포맷이 아니므로 실패를 유발함

이에 적당히 인메모리 테스트 db인 h2 경로를
새로 만든 테스트 전용 `test` 프로파일에 지정해주고,
테스트 실행 시 이 프로파일을 바라보게 하여
문제 해결